### PR TITLE
fix(groups): use boolean italic in highlight specs

### DIFF
--- a/lua/primary/groups.lua
+++ b/lua/primary/groups.lua
@@ -10,7 +10,7 @@ local M = {}
 -- Build highlight groups for dark background
 function M.build_dark(palette, cfg)
   local p = palette
-  local italic = not cfg.disable_italic and 'italic' or nil
+  local italic = not cfg.disable_italic and true or false
   
   -- Based on "dark background" branch in colors/primary.vim
   local groups = {
@@ -136,7 +136,7 @@ end
 -- Build highlight groups for light background
 function M.build_light(palette, cfg)
   local p = palette
-  local italic = not cfg.disable_italic and 'italic' or nil
+  local italic = not cfg.disable_italic and true or false
   
   -- Based on "light background" branch in colors/primary.vim
   local groups = {


### PR DESCRIPTION
This PR fixes the highlight style construction by using boolean values for italic instead of string 'italic' or nil.\n\n- Updates italic style in build_dark/build_light to true/false\n- Matches vim.api.nvim_set_hl expectations for boolean style attributes\n- Prevents inconsistent italics rendering across Neovim versions\n\nNo functional changes beyond italics style resolution.