### PR TITLE
refactor(style): normalize Lua quotes and indentation

### DIFF
--- a/colors/primary.lua
+++ b/colors/primary.lua
@@ -1,1 +1,1 @@
-require('primary').load()
+require("primary").load()

--- a/lua/primary/config.lua
+++ b/lua/primary/config.lua
@@ -5,32 +5,32 @@ local M = {}
 
 -- Helper function to parse boolean values
 local function to_boolean(value, default)
-  if value == nil then
-    return default
-  end
-  
-  -- Handle various truthy values
-  if value == true or value == 1 or value == '1' or value == 'true' then
-    return true
-  elseif value == false or value == 0 or value == '0' or value == 'false' then
-    return false
-  else
-    return default
-  end
+	if value == nil then
+		return default
+	end
+	
+	-- Handle various truthy values
+	if value == true or value == 1 or value == "1" or value == "true" then
+		return true
+	elseif value == false or value == 0 or value == "0" or value == "false" then
+		return false
+	else
+		return default
+	end
 end
 
 -- Read configuration from vim.g variables
 -- Returns a table with configuration options
 function M.read()
-  return {
-    -- Disable italic comments and strings
-    -- Default: false (italics enabled)
-    disable_italic = to_boolean(vim.g.colorscheme_primary_disable_italic, false),
-    
-    -- Enable transparent background
-    -- Default: false (opaque background)
-    transparent_bg = to_boolean(vim.g.colorscheme_primary_enable_transparent_bg, false),
-  }
+	return {
+		-- Disable italic comments and strings
+		-- Default: false (italics enabled)
+		disable_italic = to_boolean(vim.g.colorscheme_primary_disable_italic, false),
+		
+		-- Enable transparent background
+		-- Default: false (opaque background)
+		transparent_bg = to_boolean(vim.g.colorscheme_primary_enable_transparent_bg, false),
+	}
 end
 
 return M

--- a/lua/primary/groups.lua
+++ b/lua/primary/groups.lua
@@ -2,365 +2,365 @@
 -- Mapping notes:
 -- These highlight groups mirror the original VimScript implementation in
 -- colors/primary.vim. Group names, bold/italic usage, and color intent follow
--- the original scheme's sections (UI, Search, Diff, Syntax, etc.) to maintain
+-- the original scheme"s sections (UI, Search, Diff, Syntax, etc.) to maintain
 -- parity and ease future diffing against the source.
 
 local M = {}
 
 -- Build highlight groups for dark background
 function M.build_dark(palette, cfg)
-  local p = palette
-  local italic = not cfg.disable_italic and true or false
-  
-  -- Based on "dark background" branch in colors/primary.vim
-  local groups = {
-    -- Editor UI
-    Normal = { fg = p.blue, bg = p.bg },
-    NormalFloat = { fg = p.blue, bg = p.bg },
-    NonText = { fg = p.grey1, bg = p.bg, bold = true },
-    EndOfBuffer = { fg = p.grey1, bg = p.bg, bold = true },
-    
-    -- Cursor and Search
-    Cursor = { fg = p.bg, bg = p.grey1, bold = true },
-    CursorLine = { bg = p.grey2 },
-    CursorColumn = { bg = p.grey2 },
-    CursorLineNr = { fg = p.grey1, bg = p.bg, bold = true },
-    Search = { fg = p.bg, bg = p.yellow },
-    IncSearch = { fg = p.bg, bg = p.yellow },
-    
-    -- Visual mode
-    Visual = { bg = p.grey2 },
-    
-    -- Line numbers
-    LineNr = { fg = p.grey1, bg = p.grey2 },
-    SignColumn = { fg = p.yellow, bg = p.grey2 },
-    ColorColumn = { bg = p.grey2 },
-    
-    -- Status line
-    StatusLine = { fg = p.grey2, bg = p.grey1, bold = true },
-    StatusLineNC = { fg = p.grey1, bg = p.grey2 },
-    VertSplit = { fg = p.grey2, bg = p.grey1 },
-    WinSeparator = { fg = p.grey2, bg = p.grey1 }, -- Neovim 0.7+
-    
-    -- Popup menu
-    Pmenu = { fg = p.grey0, bg = p.grey2 },
-    PmenuSel = { fg = p.grey0, bg = p.blue },
-    PmenuSbar = { fg = p.grey0, bg = p.grey2 },
-    PmenuThumb = { fg = p.bg, bg = p.grey0 },
-    WildMenu = { fg = p.bg, bg = p.yellow },
-    
-    -- Folding
-    Folded = { fg = p.grey1, bg = p.grey2 },
-    FoldColumn = { fg = p.grey1, bg = p.grey2 },
-    
-    -- Messages
-    WarningMsg = { fg = p.red, bg = p.bg, bold = true },
-    ErrorMsg = { fg = p.red, bg = p.bg, bold = true },
-    ModeMsg = { fg = p.blue, bg = p.bg, bold = true },
-    MoreMsg = { fg = p.blue, bg = p.bg, bold = true },
-    Question = { fg = p.blue, bg = p.bg, bold = true },
-    
-    -- Special keys and directories
-    SpecialKey = { fg = p.grey0, bg = p.bg },
-    Directory = { fg = p.green, bg = p.bg },
-    Title = { fg = p.grey0, bold = true },
-    
-    -- Matching parentheses
-    MatchParen = { fg = p.bg, bg = p.red },
-    
-    -- Diff mode
-    DiffAdd = { fg = p.grey0, bg = p.blue },
-    DiffChange = { fg = p.grey0, bg = p.green },
-    DiffDelete = { fg = p.grey0, bg = p.red },
-    DiffText = { bg = p.grey1 },
-    
-    -- Syntax highlighting - Comments
-    Comment = { fg = p.green },
-    SpecialComment = { fg = p.green, bold = true },
-    Todo = { fg = p.bg, bg = p.yellow },
-    
-    -- Syntax highlighting - Constants
-    Constant = { fg = p.grey1 },
-    String = { fg = p.red, italic = italic },
-    Character = { fg = p.red, italic = italic },
-    Number = { fg = p.grey1 },
-    Boolean = { fg = p.grey1 },
-    Float = { fg = p.grey1 },
-    
-    -- Syntax highlighting - Identifiers
-    Identifier = { fg = p.blue, bold = true },
-    Function = { fg = p.blue, bold = true },
-    
-    -- Syntax highlighting - Statements
-    Statement = { fg = p.red, bold = true },
-    Conditional = { fg = p.red, bold = true },
-    Repeat = { fg = p.red, bold = true },
-    Label = { fg = p.red, bold = true },
-    Operator = { fg = p.grey1, bold = true },
-    Keyword = { fg = p.red, bold = true },
-    Exception = { fg = p.red, bold = true },
-    
-    -- Syntax highlighting - Preprocessor
-    PreProc = { fg = p.green, bold = true },
-    Include = { fg = p.green, bold = true },
-    Define = { fg = p.green, bold = true },
-    Macro = { fg = p.green, bold = true },
-    PreCondit = { fg = p.green, bold = true },
-    
-    -- Syntax highlighting - Types
-    Type = { fg = p.yellow, bold = true },
-    StorageClass = { fg = p.yellow, bold = true },
-    Structure = { fg = p.yellow, bold = true },
-    Typedef = { fg = p.green, italic = italic },
-    
-    -- Syntax highlighting - Special
-    Special = { fg = p.grey0 },
-    SpecialChar = { fg = p.grey0, bold = true },
-    Tag = { fg = p.grey1, bold = true },
-    Delimiter = { fg = p.grey0 },
-    Debug = { fg = p.grey0 },
-    
-    -- Syntax highlighting - Underlined
-    Underlined = { fg = p.grey1, underline = true },
-    
-    -- Syntax highlighting - Ignore/Error
-    Ignore = { fg = p.grey1 },
-    Error = { fg = p.bg, bg = p.red },
-  }
-  
-  local links = {}
-  
-  return groups, links
+	local p = palette
+	local italic = not cfg.disable_italic and true or false
+	
+	-- Based on "dark background" branch in colors/primary.vim
+	local groups = {
+		-- Editor UI
+		Normal = { fg = p.blue, bg = p.bg },
+		NormalFloat = { fg = p.blue, bg = p.bg },
+		NonText = { fg = p.grey1, bg = p.bg, bold = true },
+		EndOfBuffer = { fg = p.grey1, bg = p.bg, bold = true },
+		
+		-- Cursor and Search
+		Cursor = { fg = p.bg, bg = p.grey1, bold = true },
+		CursorLine = { bg = p.grey2 },
+		CursorColumn = { bg = p.grey2 },
+		CursorLineNr = { fg = p.grey1, bg = p.bg, bold = true },
+		Search = { fg = p.bg, bg = p.yellow },
+		IncSearch = { fg = p.bg, bg = p.yellow },
+		
+		-- Visual mode
+		Visual = { bg = p.grey2 },
+		
+		-- Line numbers
+		LineNr = { fg = p.grey1, bg = p.grey2 },
+		SignColumn = { fg = p.yellow, bg = p.grey2 },
+		ColorColumn = { bg = p.grey2 },
+		
+		-- Status line
+		StatusLine = { fg = p.grey2, bg = p.grey1, bold = true },
+		StatusLineNC = { fg = p.grey1, bg = p.grey2 },
+		VertSplit = { fg = p.grey2, bg = p.grey1 },
+		WinSeparator = { fg = p.grey2, bg = p.grey1 }, -- Neovim 0.7+
+		
+		-- Popup menu
+		Pmenu = { fg = p.grey0, bg = p.grey2 },
+		PmenuSel = { fg = p.grey0, bg = p.blue },
+		PmenuSbar = { fg = p.grey0, bg = p.grey2 },
+		PmenuThumb = { fg = p.bg, bg = p.grey0 },
+		WildMenu = { fg = p.bg, bg = p.yellow },
+		
+		-- Folding
+		Folded = { fg = p.grey1, bg = p.grey2 },
+		FoldColumn = { fg = p.grey1, bg = p.grey2 },
+		
+		-- Messages
+		WarningMsg = { fg = p.red, bg = p.bg, bold = true },
+		ErrorMsg = { fg = p.red, bg = p.bg, bold = true },
+		ModeMsg = { fg = p.blue, bg = p.bg, bold = true },
+		MoreMsg = { fg = p.blue, bg = p.bg, bold = true },
+		Question = { fg = p.blue, bg = p.bg, bold = true },
+		
+		-- Special keys and directories
+		SpecialKey = { fg = p.grey0, bg = p.bg },
+		Directory = { fg = p.green, bg = p.bg },
+		Title = { fg = p.grey0, bold = true },
+		
+		-- Matching parentheses
+		MatchParen = { fg = p.bg, bg = p.red },
+		
+		-- Diff mode
+		DiffAdd = { fg = p.grey0, bg = p.blue },
+		DiffChange = { fg = p.grey0, bg = p.green },
+		DiffDelete = { fg = p.grey0, bg = p.red },
+		DiffText = { bg = p.grey1 },
+		
+		-- Syntax highlighting - Comments
+		Comment = { fg = p.green },
+		SpecialComment = { fg = p.green, bold = true },
+		Todo = { fg = p.bg, bg = p.yellow },
+		
+		-- Syntax highlighting - Constants
+		Constant = { fg = p.grey1 },
+		String = { fg = p.red, italic = italic },
+		Character = { fg = p.red, italic = italic },
+		Number = { fg = p.grey1 },
+		Boolean = { fg = p.grey1 },
+		Float = { fg = p.grey1 },
+		
+		-- Syntax highlighting - Identifiers
+		Identifier = { fg = p.blue, bold = true },
+		Function = { fg = p.blue, bold = true },
+		
+		-- Syntax highlighting - Statements
+		Statement = { fg = p.red, bold = true },
+		Conditional = { fg = p.red, bold = true },
+		Repeat = { fg = p.red, bold = true },
+		Label = { fg = p.red, bold = true },
+		Operator = { fg = p.grey1, bold = true },
+		Keyword = { fg = p.red, bold = true },
+		Exception = { fg = p.red, bold = true },
+		
+		-- Syntax highlighting - Preprocessor
+		PreProc = { fg = p.green, bold = true },
+		Include = { fg = p.green, bold = true },
+		Define = { fg = p.green, bold = true },
+		Macro = { fg = p.green, bold = true },
+		PreCondit = { fg = p.green, bold = true },
+		
+		-- Syntax highlighting - Types
+		Type = { fg = p.yellow, bold = true },
+		StorageClass = { fg = p.yellow, bold = true },
+		Structure = { fg = p.yellow, bold = true },
+		Typedef = { fg = p.green, italic = italic },
+		
+		-- Syntax highlighting - Special
+		Special = { fg = p.grey0 },
+		SpecialChar = { fg = p.grey0, bold = true },
+		Tag = { fg = p.grey1, bold = true },
+		Delimiter = { fg = p.grey0 },
+		Debug = { fg = p.grey0 },
+		
+		-- Syntax highlighting - Underlined
+		Underlined = { fg = p.grey1, underline = true },
+		
+		-- Syntax highlighting - Ignore/Error
+		Ignore = { fg = p.grey1 },
+		Error = { fg = p.bg, bg = p.red },
+	}
+	
+	local links = {}
+	
+	return groups, links
 end
 
 -- Build highlight groups for light background
 function M.build_light(palette, cfg)
-  local p = palette
-  local italic = not cfg.disable_italic and true or false
-  
-  -- Based on "light background" branch in colors/primary.vim
-  local groups = {
-    -- Editor UI
-    Normal = { fg = p.blue, bg = p.bg },
-    NormalFloat = { fg = p.blue, bg = p.bg },
-    NonText = { fg = p.grey1, bg = p.bg, bold = true },
-    EndOfBuffer = { fg = p.grey1, bg = p.bg, bold = true },
-    
-    -- Cursor and Search
-    Cursor = { fg = p.bg, bg = p.grey1, bold = true },
-    CursorLine = { bg = p.grey2 },
-    CursorColumn = { bg = p.grey2 },
-    CursorLineNr = { fg = p.grey1, bg = p.bg, bold = true },
-    Search = { fg = p.bg, bg = p.yellow },
-    IncSearch = { fg = p.bg, bg = p.yellow },
-    
-    -- Visual mode
-    Visual = { bg = p.grey2 },
-    
-    -- Line numbers
-    LineNr = { fg = p.grey1, bg = p.grey2 },
-    SignColumn = { fg = p.yellow, bg = p.grey2 },
-    ColorColumn = { bg = p.grey2 },
-    
-    -- Status line
-    StatusLine = { fg = p.grey2, bg = p.grey1, bold = true },
-    StatusLineNC = { fg = p.grey1, bg = p.grey2 },
-    VertSplit = { fg = p.grey2, bg = p.grey1 },
-    WinSeparator = { fg = p.grey2, bg = p.grey1 }, -- Neovim 0.7+
-    
-    -- Popup menu
-    Pmenu = { fg = p.grey0, bg = p.grey2 },
-    PmenuSel = { fg = p.grey0, bg = p.blue },
-    PmenuSbar = { fg = p.grey0, bg = p.grey2 },
-    PmenuThumb = { fg = p.bg, bg = p.grey0 },
-    WildMenu = { fg = p.bg, bg = p.yellow },
-    
-    -- Folding
-    Folded = { fg = p.grey1, bg = p.grey2 },
-    FoldColumn = { fg = p.grey1, bg = p.grey2 },
-    
-    -- Messages
-    WarningMsg = { fg = p.red, bg = p.bg, bold = true },
-    ErrorMsg = { fg = p.red, bg = p.bg, bold = true },
-    ModeMsg = { fg = p.blue, bg = p.bg, bold = true },
-    MoreMsg = { fg = p.blue, bg = p.bg, bold = true },
-    Question = { fg = p.blue, bg = p.bg, bold = true },
-    
-    -- Special keys and directories
-    SpecialKey = { fg = p.grey0, bg = p.bg },
-    Directory = { fg = p.green, bg = p.bg },
-    Title = { fg = p.grey0, bold = true },
-    
-    -- Matching parentheses
-    MatchParen = { fg = p.bg, bg = p.red },
-    
-    -- Diff mode
-    DiffAdd = { fg = p.grey0, bg = p.blue },
-    DiffChange = { fg = p.grey0, bg = p.green },
-    DiffDelete = { fg = p.grey0, bg = p.red },
-    DiffText = { bg = p.grey1 },
-    
-    -- Syntax highlighting - Comments
-    Comment = { fg = p.green },
-    SpecialComment = { fg = p.green, bold = true },
-    Todo = { fg = p.bg, bg = p.yellow },
-    
-    -- Syntax highlighting - Constants
-    Constant = { fg = p.grey1 },
-    String = { fg = p.red, italic = italic },
-    Character = { fg = p.red, italic = italic },
-    Number = { fg = p.grey1 },
-    Boolean = { fg = p.grey1 },
-    Float = { fg = p.grey1 },
-    
-    -- Syntax highlighting - Identifiers
-    Identifier = { fg = p.blue, bold = true },
-    Function = { fg = p.blue, bold = true },
-    
-    -- Syntax highlighting - Statements
-    Statement = { fg = p.red, bold = true },
-    Conditional = { fg = p.red, bold = true },
-    Repeat = { fg = p.red, bold = true },
-    Label = { fg = p.red, bold = true },
-    Operator = { fg = p.grey1, bold = true },
-    Keyword = { fg = p.red, bold = true },
-    Exception = { fg = p.red, bold = true },
-    
-    -- Syntax highlighting - Preprocessor
-    PreProc = { fg = p.green, bold = true },
-    Include = { fg = p.green, bold = true },
-    Define = { fg = p.green, bold = true },
-    Macro = { fg = p.green, bold = true },
-    PreCondit = { fg = p.green, bold = true },
-    
-    -- Syntax highlighting - Types
-    Type = { fg = p.yellow, bold = true },
-    StorageClass = { fg = p.yellow, bold = true },
-    Structure = { fg = p.yellow, bold = true },
-    Typedef = { fg = p.green, italic = italic },
-    
-    -- Syntax highlighting - Special
-    Special = { fg = p.grey0 },
-    SpecialChar = { fg = p.grey0, bold = true },
-    Tag = { fg = p.grey1, bold = true },
-    Delimiter = { fg = p.grey0 },
-    Debug = { fg = p.grey0 },
-    
-    -- Syntax highlighting - Underlined
-    Underlined = { fg = p.grey1, underline = true },
-    
-    -- Syntax highlighting - Ignore/Error
-    Ignore = { fg = p.grey1 },
-    Error = { fg = p.bg, bg = p.red },
-  }
-  
-  local links = {}
-  
-  return groups, links
+	local p = palette
+	local italic = not cfg.disable_italic and true or false
+	
+	-- Based on "light background" branch in colors/primary.vim
+	local groups = {
+		-- Editor UI
+		Normal = { fg = p.blue, bg = p.bg },
+		NormalFloat = { fg = p.blue, bg = p.bg },
+		NonText = { fg = p.grey1, bg = p.bg, bold = true },
+		EndOfBuffer = { fg = p.grey1, bg = p.bg, bold = true },
+		
+		-- Cursor and Search
+		Cursor = { fg = p.bg, bg = p.grey1, bold = true },
+		CursorLine = { bg = p.grey2 },
+		CursorColumn = { bg = p.grey2 },
+		CursorLineNr = { fg = p.grey1, bg = p.bg, bold = true },
+		Search = { fg = p.bg, bg = p.yellow },
+		IncSearch = { fg = p.bg, bg = p.yellow },
+		
+		-- Visual mode
+		Visual = { bg = p.grey2 },
+		
+		-- Line numbers
+		LineNr = { fg = p.grey1, bg = p.grey2 },
+		SignColumn = { fg = p.yellow, bg = p.grey2 },
+		ColorColumn = { bg = p.grey2 },
+		
+		-- Status line
+		StatusLine = { fg = p.grey2, bg = p.grey1, bold = true },
+		StatusLineNC = { fg = p.grey1, bg = p.grey2 },
+		VertSplit = { fg = p.grey2, bg = p.grey1 },
+		WinSeparator = { fg = p.grey2, bg = p.grey1 }, -- Neovim 0.7+
+		
+		-- Popup menu
+		Pmenu = { fg = p.grey0, bg = p.grey2 },
+		PmenuSel = { fg = p.grey0, bg = p.blue },
+		PmenuSbar = { fg = p.grey0, bg = p.grey2 },
+		PmenuThumb = { fg = p.bg, bg = p.grey0 },
+		WildMenu = { fg = p.bg, bg = p.yellow },
+		
+		-- Folding
+		Folded = { fg = p.grey1, bg = p.grey2 },
+		FoldColumn = { fg = p.grey1, bg = p.grey2 },
+		
+		-- Messages
+		WarningMsg = { fg = p.red, bg = p.bg, bold = true },
+		ErrorMsg = { fg = p.red, bg = p.bg, bold = true },
+		ModeMsg = { fg = p.blue, bg = p.bg, bold = true },
+		MoreMsg = { fg = p.blue, bg = p.bg, bold = true },
+		Question = { fg = p.blue, bg = p.bg, bold = true },
+		
+		-- Special keys and directories
+		SpecialKey = { fg = p.grey0, bg = p.bg },
+		Directory = { fg = p.green, bg = p.bg },
+		Title = { fg = p.grey0, bold = true },
+		
+		-- Matching parentheses
+		MatchParen = { fg = p.bg, bg = p.red },
+		
+		-- Diff mode
+		DiffAdd = { fg = p.grey0, bg = p.blue },
+		DiffChange = { fg = p.grey0, bg = p.green },
+		DiffDelete = { fg = p.grey0, bg = p.red },
+		DiffText = { bg = p.grey1 },
+		
+		-- Syntax highlighting - Comments
+		Comment = { fg = p.green },
+		SpecialComment = { fg = p.green, bold = true },
+		Todo = { fg = p.bg, bg = p.yellow },
+		
+		-- Syntax highlighting - Constants
+		Constant = { fg = p.grey1 },
+		String = { fg = p.red, italic = italic },
+		Character = { fg = p.red, italic = italic },
+		Number = { fg = p.grey1 },
+		Boolean = { fg = p.grey1 },
+		Float = { fg = p.grey1 },
+		
+		-- Syntax highlighting - Identifiers
+		Identifier = { fg = p.blue, bold = true },
+		Function = { fg = p.blue, bold = true },
+		
+		-- Syntax highlighting - Statements
+		Statement = { fg = p.red, bold = true },
+		Conditional = { fg = p.red, bold = true },
+		Repeat = { fg = p.red, bold = true },
+		Label = { fg = p.red, bold = true },
+		Operator = { fg = p.grey1, bold = true },
+		Keyword = { fg = p.red, bold = true },
+		Exception = { fg = p.red, bold = true },
+		
+		-- Syntax highlighting - Preprocessor
+		PreProc = { fg = p.green, bold = true },
+		Include = { fg = p.green, bold = true },
+		Define = { fg = p.green, bold = true },
+		Macro = { fg = p.green, bold = true },
+		PreCondit = { fg = p.green, bold = true },
+		
+		-- Syntax highlighting - Types
+		Type = { fg = p.yellow, bold = true },
+		StorageClass = { fg = p.yellow, bold = true },
+		Structure = { fg = p.yellow, bold = true },
+		Typedef = { fg = p.green, italic = italic },
+		
+		-- Syntax highlighting - Special
+		Special = { fg = p.grey0 },
+		SpecialChar = { fg = p.grey0, bold = true },
+		Tag = { fg = p.grey1, bold = true },
+		Delimiter = { fg = p.grey0 },
+		Debug = { fg = p.grey0 },
+		
+		-- Syntax highlighting - Underlined
+		Underlined = { fg = p.grey1, underline = true },
+		
+		-- Syntax highlighting - Ignore/Error
+		Ignore = { fg = p.grey1 },
+		Error = { fg = p.bg, bg = p.red },
+	}
+	
+	local links = {}
+	
+	return groups, links
 end
 
 -- Add modern highlight groups (LSP, Treesitter, Diagnostics)
 function M.add_modern_groups(groups, links, palette, cfg)
-  local p = palette
-  
-  -- Diagnostics (Neovim 0.5+). Not in the original Vimscript; linked to
-  -- closest legacy groups to preserve visual character.
-  links.DiagnosticError = 'ErrorMsg'
-  links.DiagnosticWarn = 'WarningMsg'
-  links.DiagnosticInfo = 'ModeMsg'
-  links.DiagnosticHint = 'MoreMsg'
-  links.DiagnosticUnderlineError = 'Error'
-  links.DiagnosticUnderlineWarn = 'Todo'
-  links.DiagnosticUnderlineInfo = 'Underlined'
-  links.DiagnosticUnderlineHint = 'Underlined'
-  
-  -- LSP
-  links.LspReferenceText = 'Visual'
-  links.LspReferenceRead = 'Visual'
-  links.LspReferenceWrite = 'Visual'
-  links.LspInlayHint = 'Comment'
-  links.LspSignatureActiveParameter = 'Search'
-  
-  -- Treesitter
-  links['@comment'] = 'Comment'
-  links['@constant'] = 'Constant'
-  links['@constant.builtin'] = 'Constant'
-  links['@constant.macro'] = 'Macro'
-  links['@string'] = 'String'
-  links['@string.escape'] = 'SpecialChar'
-  links['@string.special'] = 'SpecialChar'
-  links['@character'] = 'Character'
-  links['@character.special'] = 'SpecialChar'
-  links['@number'] = 'Number'
-  links['@boolean'] = 'Boolean'
-  links['@float'] = 'Float'
-  links['@function'] = 'Function'
-  links['@function.builtin'] = 'Function'
-  links['@function.macro'] = 'Macro'
-  links['@parameter'] = 'Identifier'
-  links['@method'] = 'Function'
-  links['@field'] = 'Identifier'
-  links['@property'] = 'Identifier'
-  links['@constructor'] = 'Type'
-  links['@conditional'] = 'Conditional'
-  links['@repeat'] = 'Repeat'
-  links['@label'] = 'Label'
-  links['@operator'] = 'Operator'
-  links['@keyword'] = 'Keyword'
-  links['@exception'] = 'Exception'
-  links['@variable'] = 'Identifier'
-  links['@type'] = 'Type'
-  links['@type.definition'] = 'Typedef'
-  links['@type.builtin'] = 'Type'
-  links['@type.qualifier'] = 'StorageClass'
-  links['@storageclass'] = 'StorageClass'
-  links['@structure'] = 'Structure'
-  links['@namespace'] = 'Identifier'
-  links['@include'] = 'Include'
-  links['@preproc'] = 'PreProc'
-  links['@debug'] = 'Debug'
-  links['@tag'] = 'Tag'
-  links['@tag.delimiter'] = 'Delimiter'
-  links['@text'] = 'Normal'
-  links['@text.strong'] = 'Bold'
-  links['@text.emphasis'] = 'Italic'
-  links['@text.underline'] = 'Underlined'
-  links['@text.strike'] = 'Strikethrough'
-  links['@text.title'] = 'Title'
-  links['@text.literal'] = 'String'
-  links['@text.uri'] = 'Underlined'
-  links['@text.reference'] = 'Constant'
-  links['@text.todo'] = 'Todo'
-  links['@text.note'] = 'SpecialComment'
-  links['@text.warning'] = 'WarningMsg'
-  links['@text.danger'] = 'ErrorMsg'
-  
-  -- Git signs
-  links.GitSignsAdd = 'DiffAdd'
-  links.GitSignsChange = 'DiffChange'
-  links.GitSignsDelete = 'DiffDelete'
-  
-  -- Telescope (popular fuzzy finder)
-  links.TelescopeNormal = 'Normal'
-  links.TelescopeBorder = 'VertSplit'
-  links.TelescopeSelection = 'Visual'
-  links.TelescopeSelectionCaret = 'Error'
-  links.TelescopeMatching = 'Search'
-  
-  -- NvimTree (file explorer)
-  links.NvimTreeNormal = 'Normal'
-  links.NvimTreeFolderIcon = 'Directory'
-  links.NvimTreeFolderName = 'Directory'
-  links.NvimTreeOpenedFolderName = 'Directory'
-  links.NvimTreeEmptyFolderName = 'Comment'
-  links.NvimTreeRootFolder = 'Title'
-  links.NvimTreeSpecialFile = 'Special'
-  links.NvimTreeExecFile = 'Function'
-  links.NvimTreeGitDirty = 'DiffChange'
-  links.NvimTreeGitNew = 'DiffAdd'
-  links.NvimTreeGitDeleted = 'DiffDelete'
-  
-  return groups, links
+	local p = palette
+	
+	-- Diagnostics (Neovim 0.5+). Not in the original Vimscript; linked to
+	-- closest legacy groups to preserve visual character.
+	links.DiagnosticError = "ErrorMsg"
+	links.DiagnosticWarn = "WarningMsg"
+	links.DiagnosticInfo = "ModeMsg"
+	links.DiagnosticHint = "MoreMsg"
+	links.DiagnosticUnderlineError = "Error"
+	links.DiagnosticUnderlineWarn = "Todo"
+	links.DiagnosticUnderlineInfo = "Underlined"
+	links.DiagnosticUnderlineHint = "Underlined"
+	
+	-- LSP
+	links.LspReferenceText = "Visual"
+	links.LspReferenceRead = "Visual"
+	links.LspReferenceWrite = "Visual"
+	links.LspInlayHint = "Comment"
+	links.LspSignatureActiveParameter = "Search"
+	
+	-- Treesitter
+	links["@comment"] = "Comment"
+	links["@constant"] = "Constant"
+	links["@constant.builtin"] = "Constant"
+	links["@constant.macro"] = "Macro"
+	links["@string"] = "String"
+	links["@string.escape"] = "SpecialChar"
+	links["@string.special"] = "SpecialChar"
+	links["@character"] = "Character"
+	links["@character.special"] = "SpecialChar"
+	links["@number"] = "Number"
+	links["@boolean"] = "Boolean"
+	links["@float"] = "Float"
+	links["@function"] = "Function"
+	links["@function.builtin"] = "Function"
+	links["@function.macro"] = "Macro"
+	links["@parameter"] = "Identifier"
+	links["@method"] = "Function"
+	links["@field"] = "Identifier"
+	links["@property"] = "Identifier"
+	links["@constructor"] = "Type"
+	links["@conditional"] = "Conditional"
+	links["@repeat"] = "Repeat"
+	links["@label"] = "Label"
+	links["@operator"] = "Operator"
+	links["@keyword"] = "Keyword"
+	links["@exception"] = "Exception"
+	links["@variable"] = "Identifier"
+	links["@type"] = "Type"
+	links["@type.definition"] = "Typedef"
+	links["@type.builtin"] = "Type"
+	links["@type.qualifier"] = "StorageClass"
+	links["@storageclass"] = "StorageClass"
+	links["@structure"] = "Structure"
+	links["@namespace"] = "Identifier"
+	links["@include"] = "Include"
+	links["@preproc"] = "PreProc"
+	links["@debug"] = "Debug"
+	links["@tag"] = "Tag"
+	links["@tag.delimiter"] = "Delimiter"
+	links["@text"] = "Normal"
+	links["@text.strong"] = "Bold"
+	links["@text.emphasis"] = "Italic"
+	links["@text.underline"] = "Underlined"
+	links["@text.strike"] = "Strikethrough"
+	links["@text.title"] = "Title"
+	links["@text.literal"] = "String"
+	links["@text.uri"] = "Underlined"
+	links["@text.reference"] = "Constant"
+	links["@text.todo"] = "Todo"
+	links["@text.note"] = "SpecialComment"
+	links["@text.warning"] = "WarningMsg"
+	links["@text.danger"] = "ErrorMsg"
+	
+	-- Git signs
+	links.GitSignsAdd = "DiffAdd"
+	links.GitSignsChange = "DiffChange"
+	links.GitSignsDelete = "DiffDelete"
+	
+	-- Telescope (popular fuzzy finder)
+	links.TelescopeNormal = "Normal"
+	links.TelescopeBorder = "VertSplit"
+	links.TelescopeSelection = "Visual"
+	links.TelescopeSelectionCaret = "Error"
+	links.TelescopeMatching = "Search"
+	
+	-- NvimTree (file explorer)
+	links.NvimTreeNormal = "Normal"
+	links.NvimTreeFolderIcon = "Directory"
+	links.NvimTreeFolderName = "Directory"
+	links.NvimTreeOpenedFolderName = "Directory"
+	links.NvimTreeEmptyFolderName = "Comment"
+	links.NvimTreeRootFolder = "Title"
+	links.NvimTreeSpecialFile = "Special"
+	links.NvimTreeExecFile = "Function"
+	links.NvimTreeGitDirty = "DiffChange"
+	links.NvimTreeGitNew = "DiffAdd"
+	links.NvimTreeGitDeleted = "DiffDelete'
+	
+	return groups, links
 end
 
 return M

--- a/lua/primary/init.lua
+++ b/lua/primary/init.lua
@@ -1,160 +1,160 @@
 -- Primary colorscheme for Neovim
--- A Lua port of Google's Primary colorscheme
+-- A Lua port of Google"s Primary colorscheme
 -- Original: https://github.com/google/vim-colorscheme-primary
 
 local M = {}
 
 -- Load required modules
-local palette = require('primary.palette')
-local config = require('primary.config')
-local groups = require('primary.groups')
+local palette = require("primary.palette")
+local config = require("primary.config")
+local groups = require("primary.groups")
 
 -- Set a highlight group
 local function set_hl(name, spec)
-  vim.api.nvim_set_hl(0, name, spec)
+	vim.api.nvim_set_hl(0, name, spec)
 end
 
 -- Apply highlight groups and links
 local function apply(highlight_groups, links, cfg)
-  -- Apply regular highlight groups
-  for name, spec in pairs(highlight_groups) do
-    -- Handle italic toggle
-    if cfg.disable_italic and spec.italic then
-      spec = vim.tbl_extend('force', spec, { italic = false })
-    end
-    set_hl(name, spec)
-  end
-  
-  -- Apply links
-  for name, target in pairs(links) do
-    set_hl(name, { link = target })
-  end
+	-- Apply regular highlight groups
+	for name, spec in pairs(highlight_groups) do
+		-- Handle italic toggle
+		if cfg.disable_italic and spec.italic then
+			spec = vim.tbl_extend("force", spec, { italic = false })
+		end
+		set_hl(name, spec)
+	end
+	
+	-- Apply links
+	for name, target in pairs(links) do
+		set_hl(name, { link = target })
+	end
 end
 
 -- Apply transparent background to selected groups
 local function apply_transparency(highlight_groups, transparent)
-  if not transparent then
-    return highlight_groups
-  end
-  
-  -- Groups that should have transparent background
-  local transparent_groups = {
-    'Normal',
-    'NormalFloat', 
-    'NonText',
-    'EndOfBuffer',
-    'SignColumn',
-    'LineNr',
-    'CursorLineNr',
-    'Folded',
-    'FoldColumn',
-    'StatusLine',
-    'StatusLineNC',
-    'VertSplit',
-    'WinSeparator',
-    'WarningMsg',
-    'ErrorMsg',
-    'ModeMsg',
-    'MoreMsg',
-    'Question',
-    'SpecialKey',
-    'Directory',
-  }
-  
-  -- Clone the groups table to avoid modifying the original
-  local modified_groups = vim.tbl_deep_extend('force', {}, highlight_groups)
-  
-  for _, group in ipairs(transparent_groups) do
-    if modified_groups[group] then
-      modified_groups[group] = vim.tbl_extend('force', modified_groups[group], { bg = 'NONE' })
-    end
-  end
-  
-  return modified_groups
+	if not transparent then
+		return highlight_groups
+	end
+	
+	-- Groups that should have transparent background
+	local transparent_groups = {
+		"Normal",
+		"NormalFloat", 
+		"NonText",
+		"EndOfBuffer",
+		"SignColumn",
+		"LineNr",
+		"CursorLineNr",
+		"Folded",
+		"FoldColumn",
+		"StatusLine",
+		"StatusLineNC",
+		"VertSplit",
+		"WinSeparator",
+		"WarningMsg",
+		"ErrorMsg",
+		"ModeMsg",
+		"MoreMsg",
+		"Question",
+		"SpecialKey",
+		"Directory",
+	}
+	
+	-- Clone the groups table to avoid modifying the original
+	local modified_groups = vim.tbl_deep_extend("force", {}, highlight_groups)
+	
+	for _, group in ipairs(transparent_groups) do
+		if modified_groups[group] then
+			modified_groups[group] = vim.tbl_extend("force", modified_groups[group], { bg = "NONE" })
+		end
+	end
+	
+	return modified_groups
 end
 
 -- Set terminal colors for consistency
 local function set_terminal_colors(colors)
-  -- Map terminal colors to the palette
-  -- Standard ANSI colors
-  vim.g.terminal_color_0  = colors.BLACK   -- Black
-  vim.g.terminal_color_1  = colors.RED     -- Red
-  vim.g.terminal_color_2  = colors.GREEN   -- Green
-  vim.g.terminal_color_3  = colors.YELLOW  -- Yellow
-  vim.g.terminal_color_4  = colors.BLUE    -- Blue
-  vim.g.terminal_color_5  = colors.RED     -- Magenta (using red)
-  vim.g.terminal_color_6  = colors.BLUE    -- Cyan (using blue)
-  vim.g.terminal_color_7  = colors.LGREY   -- White
-  
-  -- Bright colors
-  vim.g.terminal_color_8  = colors.DGREY   -- Bright Black
-  vim.g.terminal_color_9  = colors.RED     -- Bright Red
-  vim.g.terminal_color_10 = colors.GREEN   -- Bright Green
-  vim.g.terminal_color_11 = colors.YELLOW  -- Bright Yellow
-  vim.g.terminal_color_12 = colors.BLUE    -- Bright Blue
-  vim.g.terminal_color_13 = colors.RED     -- Bright Magenta
-  vim.g.terminal_color_14 = colors.BLUE    -- Bright Cyan
-  vim.g.terminal_color_15 = colors.WHITE   -- Bright White
+	-- Map terminal colors to the palette
+	-- Standard ANSI colors
+	vim.g.terminal_color_0  = colors.BLACK   -- Black
+	vim.g.terminal_color_1  = colors.RED     -- Red
+	vim.g.terminal_color_2  = colors.GREEN   -- Green
+	vim.g.terminal_color_3  = colors.YELLOW  -- Yellow
+	vim.g.terminal_color_4  = colors.BLUE    -- Blue
+	vim.g.terminal_color_5  = colors.RED     -- Magenta (using red)
+	vim.g.terminal_color_6  = colors.BLUE    -- Cyan (using blue)
+	vim.g.terminal_color_7  = colors.LGREY   -- White
+	
+	-- Bright colors
+	vim.g.terminal_color_8  = colors.DGREY   -- Bright Black
+	vim.g.terminal_color_9  = colors.RED     -- Bright Red
+	vim.g.terminal_color_10 = colors.GREEN   -- Bright Green
+	vim.g.terminal_color_11 = colors.YELLOW  -- Bright Yellow
+	vim.g.terminal_color_12 = colors.BLUE    -- Bright Blue
+	vim.g.terminal_color_13 = colors.RED     -- Bright Magenta
+	vim.g.terminal_color_14 = colors.BLUE    -- Bright Cyan
+	vim.g.terminal_color_15 = colors.WHITE   -- Bright White
 end
 
 -- Main load function
 function M.load()
-  -- Clear existing highlights if needed
-  if vim.g.colors_name then
-    vim.cmd('hi clear')
-  end
-  
-  -- Reset syntax highlighting
-  if vim.fn.exists('syntax_on') then
-    vim.cmd('syntax reset')
-  end
-  
-  -- Enable true colors if available (documented behavior)
-  if vim.fn.has('termguicolors') == 1 and not vim.o.termguicolors then
-    vim.o.termguicolors = true
-  end
-  
-  -- Set the colorscheme name
-  vim.g.colors_name = 'primary'
-  
-  -- Read user configuration
-  local cfg = config.read()
-  
-  -- Get the current background setting
-  local background = vim.o.background
-  
-  -- Pick palette based on background
-  local colors = palette.pick(background)
-  
-  -- Build highlight groups based on background
-  local highlight_groups, links
-  if background == 'dark' then
-    highlight_groups, links = groups.build_dark(colors, cfg)
-  else
-    highlight_groups, links = groups.build_light(colors, cfg)
-  end
-  
-  -- Add modern highlight groups (LSP, Treesitter, etc.)
-  highlight_groups, links = groups.add_modern_groups(highlight_groups, links, colors, cfg)
-  
-  -- Apply transparency if enabled
-  highlight_groups = apply_transparency(highlight_groups, cfg.transparent_bg)
-  
-  -- Apply all highlight groups and links
-  apply(highlight_groups, links, cfg)
-  
-  -- Set terminal colors for consistency
-  set_terminal_colors(palette.colors)
+	-- Clear existing highlights if needed
+	if vim.g.colors_name then
+		vim.cmd("hi clear")
+	end
+	
+	-- Reset syntax highlighting
+	if vim.fn.exists("syntax_on") then
+		vim.cmd("syntax reset")
+	end
+	
+	-- Enable true colors if available (documented behavior)
+	if vim.fn.has("termguicolors") == 1 and not vim.o.termguicolors then
+		vim.o.termguicolors = true
+	end
+	
+	-- Set the colorscheme name
+	vim.g.colors_name = "primary"
+	
+	-- Read user configuration
+	local cfg = config.read()
+	
+	-- Get the current background setting
+	local background = vim.o.background
+	
+	-- Pick palette based on background
+	local colors = palette.pick(background)
+	
+	-- Build highlight groups based on background
+	local highlight_groups, links
+	if background == "dark" then
+		highlight_groups, links = groups.build_dark(colors, cfg)
+	else
+		highlight_groups, links = groups.build_light(colors, cfg)
+	end
+	
+	-- Add modern highlight groups (LSP, Treesitter, etc.)
+	highlight_groups, links = groups.add_modern_groups(highlight_groups, links, colors, cfg)
+	
+	-- Apply transparency if enabled
+	highlight_groups = apply_transparency(highlight_groups, cfg.transparent_bg)
+	
+	-- Apply all highlight groups and links
+	apply(highlight_groups, links, cfg)
+	
+	-- Set terminal colors for consistency
+	set_terminal_colors(palette.colors)
 end
 
 -- Setup function for configuration (optional, for future use)
 function M.setup(opts)
-  -- Could be used to set configuration options before loading
-  if opts then
-    for key, value in pairs(opts) do
-      vim.g['colorscheme_primary_' .. key] = value
-    end
-  end
+	-- Could be used to set configuration options before loading
+	if opts then
+		for key, value in pairs(opts) do
+			vim.g["colorscheme_primary_' .. key] = value
+		end
+	end
 end
 
 return M

--- a/lua/primary/palette.lua
+++ b/lua/primary/palette.lua
@@ -3,63 +3,63 @@
 
 local M = {}
 
--- Base color palette - Google's brand colors
+-- Base color palette - Google"s brand colors
 M.colors = {
-  RED    = '#EA4335',
-  GREEN  = '#34A853',
-  YELLOW = '#FBBC04',
-  BLUE   = '#4285F4',
-  BLACK  = '#202124',
-  DGREY  = '#5F6368',
-  LGREY  = '#E8EAED',
-  WHITE  = '#FFFFFF',
+	RED    = "#EA4335",
+	GREEN  = "#34A853",
+	YELLOW = "#FBBC04",
+	BLUE   = "#4285F4",
+	BLACK  = "#202124",
+	DGREY  = "#5F6368",
+	LGREY  = "#E8EAED",
+	WHITE  = "#FFFFFF",
 }
 
 -- Get colors based on background setting
 function M.pick(background)
-  local c = M.colors
-  
-  if background == 'dark' then
-    return {
-      -- Base colors
-      bg = c.BLACK,
-      fg = c.BLUE,  -- Normal fg in original is BLUE
-      
-      -- Greyscale (reversed for dark mode as per original)
-      grey0 = c.WHITE,
-      grey1 = c.LGREY,
-      grey2 = c.DGREY,
-      
-      -- Accent colors
-      red = c.RED,
-      green = c.GREEN,
-      yellow = c.YELLOW,
-      blue = c.BLUE,
-      
-      -- For transparent background
-      none = 'NONE',
-    }
-  else -- light
-    return {
-      -- Base colors  
-      bg = c.WHITE,
-      fg = c.BLUE,  -- Normal fg in original is BLUE
-      
-      -- Greyscale (normal for light mode as per original)
-      grey0 = c.BLACK,
-      grey1 = c.DGREY,
-      grey2 = c.LGREY,
-      
-      -- Accent colors
-      red = c.RED,
-      green = c.GREEN,
-      yellow = c.YELLOW,
-      blue = c.BLUE,
-      
-      -- For transparent background
-      none = 'NONE',
-    }
-  end
+	local c = M.colors
+	
+	if background == "dark" then
+		return {
+			-- Base colors
+			bg = c.BLACK,
+			fg = c.BLUE,  -- Normal fg in original is BLUE
+			
+			-- Greyscale (reversed for dark mode as per original)
+			grey0 = c.WHITE,
+			grey1 = c.LGREY,
+			grey2 = c.DGREY,
+			
+			-- Accent colors
+			red = c.RED,
+			green = c.GREEN,
+			yellow = c.YELLOW,
+			blue = c.BLUE,
+			
+			-- For transparent background
+			none = "NONE",
+		}
+	else -- light
+		return {
+			-- Base colors  
+			bg = c.WHITE,
+			fg = c.BLUE,  -- Normal fg in original is BLUE
+			
+			-- Greyscale (normal for light mode as per original)
+			grey0 = c.BLACK,
+			grey1 = c.DGREY,
+			grey2 = c.LGREY,
+			
+			-- Accent colors
+			red = c.RED,
+			green = c.GREEN,
+			yellow = c.YELLOW,
+			blue = c.BLUE,
+			
+			-- For transparent background
+			none = "NONE',
+		}
+	end
 end
 
 return M


### PR DESCRIPTION
This PR applies non-functional style changes across the Lua codebase.\n\n- Replace single quotes with double quotes for string literals\n- Convert 2-space indentation to tabs consistently\n- No behavior changes intended; improves consistency and readability\n\nFiles: colors/primary.lua, lua/primary/{config,groups,init,palette}.lua